### PR TITLE
Fixing wrong database configuration

### DIFF
--- a/core/src/main/java/org/transitclock/domain/structs/ExportTable.java
+++ b/core/src/main/java/org/transitclock/domain/structs/ExportTable.java
@@ -44,7 +44,7 @@ public class ExportTable implements Serializable {
     @Column(name = "export_status")
     private int exportStatus;
 
-    @Column(name = "first_name")
+    @Column(name = "file_name")
     private String fileName;
 
     @Column(name = "file")

--- a/core/src/main/java/org/transitclock/domain/structs/TravelTimesForTrip.java
+++ b/core/src/main/java/org/transitclock/domain/structs/TravelTimesForTrip.java
@@ -80,10 +80,10 @@ public class TravelTimesForTrip implements Serializable {
     @ManyToMany(fetch = FetchType.EAGER)
     @JoinTable(name = "travel_times_for_trip_to_travel_times_for_path",
             joinColumns = {
-                    @JoinColumn(name = "for_path_id", referencedColumnName = "id")
+                    @JoinColumn(name = "for_trip_id", referencedColumnName = "id")
             },
             inverseJoinColumns = {
-                    @JoinColumn(name = "for_trip_id", referencedColumnName = "id")
+                    @JoinColumn(name = "for_path_id", referencedColumnName = "id")
             })
     @Cascade({CascadeType.SAVE_UPDATE})
     @OrderColumn(name = "list_index")

--- a/core/src/main/java/org/transitclock/domain/structs/TripPattern.java
+++ b/core/src/main/java/org/transitclock/domain/structs/TripPattern.java
@@ -3,7 +3,6 @@ package org.transitclock.domain.structs;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import org.hibernate.CallbackException;
 import org.hibernate.HibernateException;
 import org.hibernate.Session;
 import org.hibernate.annotations.Cascade;
@@ -15,10 +14,8 @@ import org.transitclock.gtfs.model.GtfsRoute;
 
 import jakarta.persistence.*;
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * A trip pattern, as obtained from stop_times.txt GTFS file. A trip pattern defines what stops are
@@ -570,9 +567,9 @@ public class TripPattern implements Serializable, Lifecycle {
      * @return
      */
     public List<String> getStopIds() {
-        List<String> list = new ArrayList<String>(stopPaths.size());
-        for (StopPath stopPath : stopPaths) list.add(stopPath.getStopId());
-        return list;
+        return stopPaths.stream()
+                .map(StopPath::getStopId)
+                .collect(Collectors.toList());
     }
 
     /**
@@ -581,7 +578,9 @@ public class TripPattern implements Serializable, Lifecycle {
      * @return ID of last stop
      */
     public String getLastStopIdForTrip() {
-        return stopPaths.get(stopPaths.size() - 1).getStopId();
+        return Optional.ofNullable(getStopPath(stopPaths.size() - 1))
+                .map(StopPath::getStopId)
+                .orElse(null);
     }
 
     /**
@@ -602,7 +601,8 @@ public class TripPattern implements Serializable, Lifecycle {
      * @return The specified StopPath or null if index out of range
      */
     public StopPath getStopPath(int index) {
-        if (index < 0 || index >= stopPaths.size()) return null;
+        if (index < 0 || index >= stopPaths.size())
+            return null;
 
         return stopPaths.get(index);
     }

--- a/core/src/main/resources/db/migration/V20240516223700__fix-wrong-column-for-export-table.sql
+++ b/core/src/main/resources/db/migration/V20240516223700__fix-wrong-column-for-export-table.sql
@@ -1,0 +1,1 @@
+ALTER TABLE export_table RENAME COLUMN first_name TO file_name;

--- a/core/src/main/resources/db/migration/V20240516223701__fix-wrong-relation.sql
+++ b/core/src/main/resources/db/migration/V20240516223701__fix-wrong-relation.sql
@@ -1,0 +1,13 @@
+-- removing faulty constraints definitions
+ALTER TABLE travel_times_for_trip_to_travel_times_for_path
+    DROP CONSTRAINT fk_tratimfortritotratimforpat_on_travel_times_for_stop_path;
+
+ALTER TABLE travel_times_for_trip_to_travel_times_for_path
+    DROP CONSTRAINT fk_tratimfortritotratimforpat_on_travel_times_for_trip;
+
+-- recreating new constraints
+ALTER TABLE travel_times_for_trip_to_travel_times_for_path
+    ADD CONSTRAINT fk_tratimfortritotratimforpat_on_travel_times_for_stop_path FOREIGN KEY (for_path_id) REFERENCES travel_times_for_stop_paths (id);
+
+ALTER TABLE travel_times_for_trip_to_travel_times_for_path
+    ADD CONSTRAINT fk_tratimfortritotratimforpat_on_travel_times_for_trip FOREIGN KEY (for_trip_id) REFERENCES travel_times_for_trips (id);

--- a/extensions/traccar/pom.xml
+++ b/extensions/traccar/pom.xml
@@ -20,6 +20,8 @@
     <maven-plugin-version>1.0.0</maven-plugin-version>
   </properties>
 
+  <packaging>jar</packaging>
+
   <build>
     <plugins>
       <!-- activate the plugin -->

--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,7 @@
                     <configuration>
                         <javaVersion>17</javaVersion>
                         <failOnViolations>false</failOnViolations>
+                        <includeTestClasses>false</includeTestClasses>
                     </configuration>
                     <executions>
                         <execution>


### PR DESCRIPTION
Fixing db relations discovered in goeuropa deployment

changed the foreign keys for travel_times_for_trip_to_travel_times_for_path
fixed the name used for export-table